### PR TITLE
Naïve fix for #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,97 @@
+reated by https://www.gitignore.io/api/python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+.venv/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# End of https://www.gitignore.io/api/python
+

--- a/avclass_labeler.py
+++ b/avclass_labeler.py
@@ -83,6 +83,9 @@ def main(args):
             # Read JSON line and extract sample info (i.e., hashes and labels)
             vt_rep = json.loads(line)
             sample_info = av_labels.get_sample_info(vt_rep, args.vt)
+            if sample_info is None:
+                print ""
+                return
             name = getattr(sample_info, hash_type)
 
             # If the VT report has no AV labels, continue

--- a/lib/avclass_common.py
+++ b/lib/avclass_common.py
@@ -66,6 +66,8 @@ class AvLabels:
         label_pairs = []
         if from_vt:
             try:
+                if not vt_rep:
+                    return None
                 scans = vt_rep['scans']
             except KeyError:
                 return None


### PR DESCRIPTION
I naïvely fixed #2 just by aborting the labeler (instead of crashing) on invalid input.