### PR TITLE
Skip empty lines on default.aliases

### DIFF
--- a/lib/avclass_common.py
+++ b/lib/avclass_common.py
@@ -36,7 +36,10 @@ class AvLabels:
         almap = {}
         with open(alfile, 'r') as fd:
             for line in fd:
-                alias, token = line.strip().split()[0:2]
+                tmp_line = line.strip().split()[0:2]
+                if len(tmp_line) == 0:
+                    continue
+                alias, token = tmp_line
                 almap[alias] = token
         return almap
 


### PR DESCRIPTION
Currently if there is an empty line on default.aliases file, avclass_labeler will crash:

```
: [-] Using generic tokens in /avclass/data/default.generics
: Traceback (most recent call last):
:   File "/avclass/avclass_labeler.py", line 445, in <module>
:     main(args)
:   File "/avclass/avclass_labeler.py", line 51, in main
:     av_labels = AvLabels(args.gen, args.alias, args.av)
:   File "/avclass/lib/avclass_common.py", line 26, in __init__
:     self.aliases_map = self.read_aliases(alias_file) if alias_file else {}
:   File "/avclass/lib/avclass_common.py", line 39, in read_aliases
:     alias, token = line.strip().split()[0:2]
: ValueError: need more than 0 values to unpack
```

This patch fixes that.