### PR TITLE
Use VT APIv3

### DIFF
--- a/avclass_labeler.py
+++ b/avclass_labeler.py
@@ -107,6 +107,11 @@ def main(args):
 
             # Read JSON line and extract sample info (i.e., hashes and labels)
             vt_rep = json.loads(line)
+
+            # VT APIv3 begins with "data" key
+            if "data" in vt_rep:
+                vt_rep = vt_rep["data"]
+            
             sample_info = av_labels.get_sample_info(vt_rep, ifile_are_vt)
             if sample_info is None:
                 try:

--- a/lib/avclass_common.py
+++ b/lib/avclass_common.py
@@ -65,23 +65,16 @@ class AvLabels:
         '''
         label_pairs = []
         if from_vt:
-            # V2 reports
+
             try:
-                scans = vt_rep['scans']
-                md5 = vt_rep['md5']
-                sha1 = vt_rep['sha1']
-                sha256 = vt_rep['sha256']
-            # V3 reports
+                scans = vt_rep['attributes']['last_analysis_results']
+                md5 = vt_rep['attributes']['md5']
+                sha1 = vt_rep['attributes']['sha1']
+                sha256 = vt_rep['attributes']['sha256']
             except KeyError:
-                try:
-                    scans = vt_rep['attributes']['last_analysis_results']
-                    md5 = vt_rep['attributes']['md5']
-                    sha1 = vt_rep['attributes']['sha1']
-                    sha256 = vt_rep['attributes']['sha256']
-                except KeyError:
-                    return None
+                return None
             for av, res in scans.items():
-                if res['detected']:
+                if res['result'] != None:
                     label = res['result']
                     clean_label = ''.join(filter(
                                       lambda x: x in string.printable, 


### PR DESCRIPTION
VirusTotal APIv2 is deprecated for over a year now and shouldn't be used.
The support for API V3 was broken and didn't really work. The mixture of supporting obsolete API (v2) with the newer one (v3) doesn't go well.

This PR, removes the parsing of VT APIv2 in favor of APIv3 and fixes the issues