### PR TITLE
Redline <-> reline mapping problems

### DIFF
--- a/avclass/data/default.tagging
+++ b/avclass/data/default.tagging
@@ -2296,10 +2296,11 @@ rebonum	umbreon
 recal	mogap
 recam	netwiredrc
 recordpage	browsefox
+recordstealer	redline
 redirector	network
-redline	reline
-redlinesteal	reline
-redlinestealer	reline
+reline redline
+redlinesteal	redline
+redlinestealer	redline
 redolf	redlof
 reefwal	kalfere
 refogkeylogger	refog

--- a/avclass/data/default.taxonomy
+++ b/avclass/data/default.taxonomy
@@ -2108,6 +2108,7 @@ FAM:redaman
 FAM:redcap
 FAM:rediassi
 FAM:redleaves
+FAM:redline
 FAM:redlof
 FAM:redmobile
 FAM:redosdru
@@ -2123,7 +2124,6 @@ FAM:regretlocker
 FAM:reimage
 FAM:rekoobe
 FAM:relevantknowledge
-FAM:reline
 FAM:remaiten
 FAM:remcom
 FAM:remcos


### PR DESCRIPTION
Hi everyone,

We've been using AVClass for a while and noticed that it consistently labels the "Redline" family as "Reline" (missing the 'd'). After comparing results with other labeling tools, we realized this issue is specific to AVClass.

Looking into the code, we found that AVClass maps "redline" (and its variants) to "reline" (though it's unclear why). Let's consider the following example. The attached `samples.json` file contains the VT results of the following three samples:

- https://www.virustotal.com/gui/file/d759dd894726e4cefc1343622d8ae22d335ce3681dd15e3e22e8d8999b77a3cb
- https://www.virustotal.com/gui/file/0b8b47a620667ce21d9055a7a8cb14b076e8c060d66ebbf1f13e67030b9d50c8
- https://www.virustotal.com/gui/file/4b2609c28ab96acc7e9118f4b31bdbdda17cda77750bcc7c6dc3aaf3a8541025

Attached file: [samples.json](https://github.com/user-attachments/files/20902427/samples.json)

At the moment of this writing, a quick search for "reline" has no matches in any of these VT entries' vendors results, whereas "redline" has at least 4 occurrences.

`avclass` produces the following output
```
$ avclass -f samples.json 
[-] Using tagging rules in [REDACTED]/avclass/data/default.tagging
[-] Using taxonomy in [REDACTED]/avclass/data/default.taxonomy
[-] Using expansion tags in [REDACTED]/avclass/data/default.expansion
[-] Processing input file samples.json (lb)
2a4706a20c2b6353cc65a2e21925d733	reline
e2b0397ba16e285829a1bb100995b7fb	reline
5c144e82b30fe477e725744585804dfc	reline
[-] 3 reports read
[-] Samples: 3 NoScans: 0 NoTags: 0 GroundTruth: 0
```

What is more, "redline" has a dedicated Malepdia entry, while "reline" does not. 
- https://malpedia.caad.fkie.fraunhofer.de/details/win.redline_stealer

Furthermore, a quick Google search produces the following results as of today:
- `"redline" malware` -> about 235K results
- `"reline" malware` -> about 2.9K results and the use of "redline" is suggested

In summary, I think the mapping of redline* -> reline should be the other way around.

With the proposed changes I find the output more accurate:
```
[-] Processing input file samples.json (lb)
2a4706a20c2b6353cc65a2e21925d733	redline
e2b0397ba16e285829a1bb100995b7fb	redline
5c144e82b30fe477e725744585804dfc	redline
[-] 3 reports read
[-] Samples: 3 NoScans: 0 NoTags: 0 GroundTruth: 0
```